### PR TITLE
Sort facets by value

### DIFF
--- a/src/dataselectie_proxy/search/clients.py
+++ b/src/dataselectie_proxy/search/clients.py
@@ -196,7 +196,7 @@ class AzureSearchServiceClient(BaseClient):
             if param in facets:
                 facets.remove(param)
 
-        facet_list = [f"{facet},count:1400" for facet in facets]
+        facet_list = [f"{facet},count:1400,sort:value" for facet in facets]
 
         return {
             "facets": facet_list,


### PR DESCRIPTION
The "postcode" facetlist can have way more than 1400 items. Returning the results at random leaves gaps between postcodes, making it look like records are missing. This is confusing for endusers. By sorting alphabetically the frontend can show a list without gaps, with a warning on the bottom that not all facets are shown.